### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts-alpine
+
+WORKDIR /opt/proxy
+
+COPY . .
+RUN npm install
+
+ENTRYPOINT [ "node", "index.js" ]

--- a/config.js
+++ b/config.js
@@ -1,0 +1,13 @@
+const config = require("./config.json");
+
+module.exports = {
+  name: process.env.SERVER_NAME || config.name,
+  publicAddr: process.env.PUBLIC_ADDRESS || config.publicAddr,
+  maxPlayers: process.env.MAX_PLAYERS || config.maxPlayers,
+  external: {
+    port: process.env.EXTERNAL_PORT || config.external.port,
+  },
+  internal: {
+    port: process.env.INTERNAL_PORT || config.internal.port,
+  },
+};

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 const axios = require('axios')
 const express = require('express');
 const { createProxyMiddleware } = require('http-proxy-middleware');
-const config = require('./config.json');
+const config = require('./config');
 
-if(config.name == "ServerName") console.log("Please change the name in config.json");
+if(config.name == "ServerName") console.log("Please change the name in config.json or via the environment (SERVER_NAME)");
 
 const app = express();
 


### PR DESCRIPTION
In this pull request support for docker has been added.

This mean that:
1. A `Dockerfile` has been added to build the Docker Image
2. The proxy has been made configurable via environment variables

---

### The following environment variables exist now to configure the proxy:
`SERVER_NAME`: The name of the server
`PUBLIC_ADDRESS`: The public address of the server
`MAX_PLAYERS`: The maximum amount of players that can join the server
`EXTERNAL_PORT`: The port that the proxy binds to
`INTERNAL_PORT`: The port of the relay / backend server

---

### Whats not included in this Pull Request
- Support for automatically building the Docker Image and publishing it as GitHub Package