### PR TITLE
Provide Endpoint to receive Server Mod Information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM node:lts-alpine
 WORKDIR /opt/proxy
 
 COPY . .
-RUN npm install
+RUN apk add python3 && npm install
 
 ENTRYPOINT [ "npm", "start" ]

--- a/config.json
+++ b/config.json
@@ -14,5 +14,9 @@
         "host": "127.0.0.1",
         "port": 6380
     },
-    "postgres": "postgres://viper:@127.0.0.1:5434/viper"
+    "postgres": "postgres://viper:@127.0.0.1:5434/viper",
+    "mod": {
+        "dirPath": "mods",
+        "configDirPath": "configs"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "express": "^4.18.2",
     "http-proxy": "^1.18.1",
     "http-proxy-middleware": "^2.0.6",
+    "jszip": "^3.10.1",
+    "knockoutcity-mod-loader": "^1.0.0-alpha.15",
     "prisma": "^5.4.1",
     "redis": "^4.6.7"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,5 +36,9 @@ export default {
     port: process.env.REDIS_PORT || config.redis.port,
     password: process.env.REDIS_PASSWORD || config.redis.password || undefined,
   },
-  postgres: process.env.DATABASE_URL || config.postgres
+  postgres: process.env.DATABASE_URL || config.postgres,
+  mod: {
+    dirPath: process.env.MOD_DIR_PATH || config.mod.dirPath,
+    configDirPath: process.env.MOD_CONFIG_DIR_PATH || config.mod.configDirPath,
+  },
 } satisfies config

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,12 @@ export interface config {
         password?: string,
     },
     postgres: string,
+    mod: {
+        /** The path to the mods directory */
+        dirPath: string,
+        /** The path to the mods configuration directory */
+        configDirPath: string,
+    },
 }
 
 

--- a/src/ziputil.ts
+++ b/src/ziputil.ts
@@ -1,0 +1,63 @@
+// Source: https://github.com/Stuk/jszip/issues/386
+
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import JSZip from 'jszip';
+
+/**
+ * Compresses a folder to the specified zip file.
+ * @param {string} srcDir
+ * @param {string} destFile
+ */
+export const compressFolder = async (srcDir: string, destFile: string): Promise<void> => {
+  //node write stream wants dest dir to already be created
+  await fsp.mkdir(path.dirname(destFile), { recursive: true });
+
+  const zip = await createZipFromFolder(srcDir);
+
+  return new Promise((resolve, reject) => {
+    zip
+      .generateNodeStream({ streamFiles: true, compression: 'DEFLATE' })
+      .pipe(fs.createWriteStream(destFile))
+      .on('error', (err) => reject(err))
+      .on('finish', resolve);
+  });
+};
+
+/**
+ * Returns a flat list of all files and subfolders for a directory (recursively).
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+const getFilePathsRecursively = async (dir: string): Promise<string[]> => {
+  // returns a flat array of absolute paths of all files recursively contained in the dir
+  const list = await fsp.readdir(dir);
+  const statPromises = list.map(async (file) => {
+    const fullPath = path.resolve(dir, file);
+    const stat = await fsp.stat(fullPath);
+    if (stat && stat.isDirectory()) {
+      return getFilePathsRecursively(fullPath);
+    }
+    return fullPath;
+  });
+
+  // cast to string[] is ts hack
+  // see: https://github.com/microsoft/TypeScript/issues/36554
+  return (await Promise.all(statPromises)).flat(Number.POSITIVE_INFINITY) as string[];
+};
+
+/**
+ * Creates an in-memory zip stream from a folder in the file system
+ * @param {string} dir
+ * @returns {Promise<JSZip>}
+ */
+export const createZipFromFolder = async (dir: string): Promise<JSZip> => {
+  const filePaths = await getFilePathsRecursively(dir);
+  return filePaths.reduce((z, filePath) => {
+    const relative = path.relative(dir, filePath);
+    return z.file(relative, fs.createReadStream(filePath), {
+      unixPermissions: '777', //you probably want less permissive permissions
+    });
+  }, new JSZip());
+};


### PR DESCRIPTION
Added two new Endpoints:
- `/mods/list` to get a list of all required mods to play on the server.
- `/mods/download` to download the mod files from the server. Provides a `.zip` file with the generated output.

Added two new configuration entries:
- `mod.dirPath`: The path to the servers mod directory
- `mod.configDirPath` : The path to the server mod configuration directory

Added two new environment variables:
- `MOD_DIR_PATH`: The same as the config `mod.dirPath`
- `MOD_CONFIG_DIR_PATH`: The same as the config `mod.configDirPath`

**About mod evaluation**:
The `server-client` mods get evaluated on the server side and the generated output will be stored in a `os.tempdir()`.
This would be `/temp` on Linux and `%temp%` on Windows.