### PR TITLE
feat: Add stats watcher and webhook integration for Trophy/MetArena platforms

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,39 @@
+{
+    "name": "ServerName",
+    "authServer": "https://api.kocity.xyz",
+    "publicAddr": "127.0.0.1:23600",
+    "maxPlayers": 50,
+    "external": {
+        "port": 23600
+    },
+    "internal": {
+        "host": "127.0.0.1",
+        "port": 23500
+    },
+    "redis": {
+        "host": "127.0.0.1",
+        "port": 6380,
+        "password": ""
+    },
+    "postgres": "postgres://viper:viper@127.0.0.1:5434/viper",
+
+    "statsWatcher": {
+        "enabled": false,
+        "gameDbUrl": "postgres://viper:viper@127.0.0.1:5434/viper",
+        "pollIntervalMs": 5000
+    },
+
+    "trophy": {
+        "enabled": false,
+        "url": "https://your-trophy-server.com/api/kocity",
+        "secret": "",
+        "gameSlug": "knockout-city"
+    },
+
+    "metarena": {
+        "enabled": false,
+        "url": "https://your-metarena-server.com/api/kocity",
+        "secret": "",
+        "serverId": "your-server-id"
+    }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,40 +1,49 @@
 import fs from "fs";
 
-import { config } from "./interfaces"
+const configFile = JSON.parse(fs.readFileSync("./config.json", "utf8"));
 
-const config = JSON.parse(fs.readFileSync("./config.json", "utf8"));
+const maxPlayers = process.env.MAX_PLAYERS || configFile.maxPlayers
 
-const maxPlayers = process.env.MAX_PLAYERS || config.maxPlayers
-
-/**
- * This exports a default object that contains the configuration for the server.
- * The object contains the following properties:
- * - name: the name of the server, taken from the environment variable SERVER_NAME or the config file.
- * - authServer: the URL of the authentication server, taken from the environment variable AUTH_SERVER or the config file.
- * - publicAddr: the public address of the server, taken from the environment variable PUBLIC_ADDRESS or the config file.
- * - maxPlayers: the maximum number of players allowed on the server, taken from the environment variable MAX_PLAYERS or the config file.
- * - external: an object containing the following properties:
- *   - port: the port number for external connections, taken from the environment variable EXTERNAL_PORT or the config file.
- * - internal: an object containing the following properties:
- *   - host: the host name for internal connections, taken from the environment variable INTERNAL_HOST or the config file.
- *   - port: the port number for internal connections, taken from the environment variable INTERNAL_PORT or the config file.
- */
 export default {
-  name: process.env.SERVER_NAME || config.name,
-  authServer: process.env.AUTH_SERVER || config.authServer,
-  publicAddr: process.env.PUBLIC_ADDRESS || config.publicAddr,
+  name: process.env.SERVER_NAME || configFile.name,
+  authServer: process.env.AUTH_SERVER || configFile.authServer,
+  publicAddr: process.env.PUBLIC_ADDRESS || configFile.publicAddr,
   maxPlayers: typeof maxPlayers != "number" ? parseInt(maxPlayers) : maxPlayers,
   external: {
-    port: process.env.EXTERNAL_PORT || config.external.port,
+    port: process.env.EXTERNAL_PORT || configFile.external.port,
   },
   internal: {
-    host: process.env.INTERNAL_HOST || config.internal.host,
-    port: process.env.INTERNAL_PORT || config.internal.port,
+    host: process.env.INTERNAL_HOST || configFile.internal.host,
+    port: process.env.INTERNAL_PORT || configFile.internal.port,
   },
   redis: {
-    host: process.env.REDIS_HOST || config.redis.host,
-    port: process.env.REDIS_PORT || config.redis.port,
-    password: process.env.REDIS_PASSWORD || config.redis.password || undefined,
+    host: process.env.REDIS_HOST || configFile.redis.host,
+    port: process.env.REDIS_PORT || configFile.redis.port,
+    password: process.env.REDIS_PASSWORD || configFile.redis.password || undefined,
   },
-  postgres: process.env.DATABASE_URL || config.postgres
-} satisfies config
+  postgres: process.env.DATABASE_URL || configFile.postgres,
+  
+  // Stats Watcher - monitors game database for match completions
+  statsWatcher: {
+    enabled: process.env.STATS_WATCHER_ENABLED === 'true' || configFile.statsWatcher?.enabled || false,
+    gameDbUrl: process.env.GAME_DB_URL || configFile.statsWatcher?.gameDbUrl || 'postgres://viper:viper@127.0.0.1:5434/viper',
+    pollIntervalMs: parseInt(process.env.STATS_WATCHER_POLL_INTERVAL || configFile.statsWatcher?.pollIntervalMs || '5000'),
+  },
+  
+  // Trophy Platform webhook - for achievement tracking and sponsorships
+  trophy: {
+    enabled: process.env.TROPHY_ENABLED === 'true' || configFile.trophy?.enabled || false,
+    url: process.env.TROPHY_URL || configFile.trophy?.url || '',
+    secret: process.env.TROPHY_SECRET || configFile.trophy?.secret || '',
+    gameSlug: process.env.TROPHY_GAME_SLUG || configFile.trophy?.gameSlug || 'knockout-city',
+  },
+  
+  // MetArena webhook - for tournament bracket updates
+  metarena: {
+    enabled: process.env.METARENA_ENABLED === 'true' || configFile.metarena?.enabled || false,
+    url: process.env.METARENA_URL || configFile.metarena?.url || '',
+    secret: process.env.METARENA_SECRET || configFile.metarena?.secret || '',
+    serverId: process.env.METARENA_SERVER_ID || configFile.metarena?.serverId || '',
+    serverName: process.env.SERVER_NAME || configFile.name || 'KOCity Server',
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ import { PrismaClient } from '@prisma/client'
 
 import Logger from './logger.js'
 
+import { StatsWatcher } from './stats-watcher';
+import { TrophyWebhook } from './webhooks-trophy';
+import { MetArenaWebhook } from './webhooks-metarena';
 import { authError, authResponse, authErrorData } from './interfaces'
 
 const log = new Logger();
@@ -44,6 +47,17 @@ prisma.$connect().then(() => {
     log.fatal(err.stack ? err.stack.toString() : '');
     process.exit(1);
 });
+// Initialize webhooks (if enabled in config)
+const trophyWebhook = config.trophy.enabled ? new TrophyWebhook(config.trophy) : null;
+const metarenaWebhook = config.metarena.enabled ? new MetArenaWebhook(config.metarena) : null;
+
+// Initialize and start Stats Watcher (if enabled in config)
+const statsWatcher = new StatsWatcher(config.statsWatcher, trophyWebhook, metarenaWebhook);
+setTimeout(() => {
+    statsWatcher.start().catch(err => {
+        log.err(`Failed to start stats watcher: ${err.message}`);
+    });
+}, 2000);
 
 const app = express();
 

--- a/src/stats-watcher.ts
+++ b/src/stats-watcher.ts
@@ -1,0 +1,305 @@
+// ============================================================================
+// AUTHPROXY - STATS WATCHER MODULE
+// Monitors game database for match completions and triggers webhooks
+// ============================================================================
+
+import { PrismaClient } from '@prisma/client';
+import Logger from './logger';
+import { TrophyWebhook } from './webhooks-trophy';
+import { MetArenaWebhook } from './webhooks-metarena';
+
+const log = new Logger();
+
+export interface StatsWatcherConfig {
+    enabled: boolean;
+    gameDbUrl: string;
+    pollIntervalMs: number;
+}
+
+interface PlayerStats {
+    wins: number;
+    mvps: number;
+    total_games_played: number;
+    current_mmr: number;
+    win_streak: number;
+}
+
+interface CachedPlayer {
+    stats: PlayerStats;
+    odinalId: string;
+    username: string;
+    publisherUsername: string;
+    playlistGuid: string;
+    matchFlow: number;
+    lastSeen: Date;
+}
+
+export class StatsWatcher {
+    private config: StatsWatcherConfig;
+    private gamePrisma: PrismaClient | null = null;
+    private playerCache: Map<string, CachedPlayer> = new Map();
+    private pollInterval: NodeJS.Timeout | null = null;
+    private isRunning: boolean = false;
+    private trophyWebhook: TrophyWebhook | null;
+    private metarenaWebhook: MetArenaWebhook | null;
+
+    constructor(
+        config: StatsWatcherConfig,
+        trophyWebhook: TrophyWebhook | null = null,
+        metarenaWebhook: MetArenaWebhook | null = null
+    ) {
+        this.config = config;
+        this.trophyWebhook = trophyWebhook;
+        this.metarenaWebhook = metarenaWebhook;
+    }
+
+    async start(): Promise<boolean> {
+        if (!this.config.enabled) {
+            log.info('[StatsWatcher] Disabled in config');
+            return false;
+        }
+
+        if (this.isRunning) {
+            log.warn('[StatsWatcher] Already running');
+            return true;
+        }
+
+        log.info('[StatsWatcher] Starting...');
+        log.info(`[StatsWatcher] Game DB: ${this.config.gameDbUrl.replace(/:[^:@]+@/, ':****@')}`);
+        log.info(`[StatsWatcher] Poll interval: ${this.config.pollIntervalMs}ms`);
+        log.info(`[StatsWatcher] Trophy webhook: ${this.trophyWebhook ? 'enabled' : 'disabled'}`);
+        log.info(`[StatsWatcher] MetArena webhook: ${this.metarenaWebhook ? 'enabled' : 'disabled'}`);
+
+        try {
+            this.gamePrisma = new PrismaClient({
+                datasources: {
+                    db: { url: this.config.gameDbUrl }
+                }
+            });
+            await this.gamePrisma.$connect();
+            log.info('[StatsWatcher] Connected to game database');
+        } catch (error: any) {
+            log.err(`[StatsWatcher] Failed to connect to game database: ${error.message}`);
+            return false;
+        }
+
+        await this.populateCache();
+
+        this.pollInterval = setInterval(() => {
+            this.checkForStatChanges();
+        }, this.config.pollIntervalMs);
+
+        this.isRunning = true;
+        log.info(`[StatsWatcher] Running. Tracking ${this.playerCache.size} player records`);
+        return true;
+    }
+
+    async stop(): Promise<void> {
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+        if (this.gamePrisma) {
+            await this.gamePrisma.$disconnect();
+            this.gamePrisma = null;
+        }
+        this.isRunning = false;
+        log.info('[StatsWatcher] Stopped');
+    }
+
+    private async populateCache(): Promise<void> {
+        if (!this.gamePrisma) return;
+
+        try {
+            const skills = await this.gamePrisma.skill.findMany({
+                include: {
+                    users: {
+                        select: { id: true, username: true, publisher_username: true }
+                    }
+                }
+            });
+
+            for (const skill of skills) {
+                const cacheKey = `${skill.user_id}-${skill.playlist_guid}-${skill.match_flow}`;
+                
+                this.playerCache.set(cacheKey, {
+                    stats: {
+                        wins: skill.wins || 0,
+                        mvps: skill.mvps || 0,
+                        total_games_played: skill.total_games_played || 0,
+                        current_mmr: skill.current_mmr || 2500,
+                        win_streak: skill.win_streak || 0
+                    },
+                    odinalId: skill.user_id.toString(),
+                    username: skill.users.username,
+                    publisherUsername: skill.users.publisher_username,
+                    playlistGuid: skill.playlist_guid,
+                    matchFlow: skill.match_flow,
+                    lastSeen: new Date()
+                });
+            }
+        } catch (error: any) {
+            log.err(`[StatsWatcher] Failed to populate cache: ${error.message}`);
+        }
+    }
+
+    private async checkForStatChanges(): Promise<void> {
+        if (!this.gamePrisma) return;
+
+        try {
+            const skills = await this.gamePrisma.skill.findMany({
+                include: {
+                    users: {
+                        select: { id: true, username: true, publisher_username: true }
+                    }
+                }
+            });
+
+            for (const skill of skills) {
+                const cacheKey = `${skill.user_id}-${skill.playlist_guid}-${skill.match_flow}`;
+                
+                const currentStats: PlayerStats = {
+                    wins: skill.wins || 0,
+                    mvps: skill.mvps || 0,
+                    total_games_played: skill.total_games_played || 0,
+                    current_mmr: skill.current_mmr || 2500,
+                    win_streak: skill.win_streak || 0
+                };
+
+                const cached = this.playerCache.get(cacheKey);
+                
+                if (cached && currentStats.total_games_played > cached.stats.total_games_played) {
+                    await this.onMatchCompleted(cached, currentStats, skill.playlist_guid);
+                }
+
+                this.playerCache.set(cacheKey, {
+                    stats: currentStats,
+                    odinalId: skill.user_id.toString(),
+                    username: skill.users.username,
+                    publisherUsername: skill.users.publisher_username,
+                    playlistGuid: skill.playlist_guid,
+                    matchFlow: skill.match_flow,
+                    lastSeen: new Date()
+                });
+            }
+        } catch (error: any) {
+            log.err(`[StatsWatcher] Poll error: ${error.message}`);
+        }
+    }
+
+    private async onMatchCompleted(cached: CachedPlayer, current: PlayerStats, playlistGuid: string): Promise<void> {
+        const winsGained = current.wins - cached.stats.wins;
+        const mvpsGained = current.mvps - cached.stats.mvps;
+        const mmrChange = current.current_mmr - cached.stats.current_mmr;
+        const won = winsGained > 0;
+
+        log.info(`[StatsWatcher] ========================================`);
+        log.info(`[StatsWatcher] MATCH COMPLETED: ${cached.username}`);
+        log.info(`[StatsWatcher] Result: ${won ? 'WIN' : 'LOSS'}`);
+        log.info(`[StatsWatcher] MVP: ${mvpsGained > 0 ? 'YES' : 'NO'}`);
+        log.info(`[StatsWatcher] MMR: ${mmrChange >= 0 ? '+' : ''}${mmrChange} (${current.current_mmr})`);
+        log.info(`[StatsWatcher] Win Streak: ${current.win_streak}`);
+        log.info(`[StatsWatcher] ========================================`);
+
+        // Send to Trophy
+        if (this.trophyWebhook) {
+            await this.trophyWebhook.sendMatchComplete({
+                odinalId: cached.odinalId,
+                username: cached.username,
+                won,
+                isMvp: mvpsGained > 0,
+                mmrChange,
+                newMmr: current.current_mmr,
+                winStreak: current.win_streak,
+                playlistGuid
+            });
+        }
+
+        // Send to MetArena
+        if (this.metarenaWebhook) {
+            await this.metarenaWebhook.sendMatchComplete({
+                odinalId: cached.odinalId,
+                username: cached.username,
+                won,
+                isMvp: mvpsGained > 0,
+                mmrChange,
+                newMmr: current.current_mmr,
+                winStreak: current.win_streak,
+                playlistGuid
+            });
+        }
+
+        // Check achievements
+        await this.checkAchievements(cached, current);
+    }
+
+    private async checkAchievements(cached: CachedPlayer, current: PlayerStats): Promise<void> {
+        const prev = cached.stats;
+        const achievements: Array<{id: string; name: string; description: string}> = [];
+
+        if (prev.total_games_played === 0 && current.total_games_played >= 1) {
+            achievements.push({ id: 'first_game', name: 'Welcome to the Streets', description: 'Play your first match' });
+        }
+
+        if (prev.wins === 0 && current.wins >= 1) {
+            achievements.push({ id: 'first_win', name: 'First Victory', description: 'Win your first match' });
+        }
+
+        for (const m of [10, 25, 50, 100, 250, 500, 1000]) {
+            if (prev.wins < m && current.wins >= m) {
+                achievements.push({ id: `wins_${m}`, name: `${m} Wins`, description: `Win ${m} matches` });
+            }
+        }
+
+        for (const m of [1, 10, 25, 50, 100]) {
+            if (prev.mvps < m && current.mvps >= m) {
+                achievements.push({ id: `mvps_${m}`, name: m === 1 ? 'First MVP' : `${m} MVPs`, description: m === 1 ? 'Earn your first MVP' : `Earn ${m} MVP awards` });
+            }
+        }
+
+        for (const m of [3, 5, 10, 20]) {
+            if (prev.win_streak < m && current.win_streak >= m) {
+                achievements.push({ id: `streak_${m}`, name: `${m} Win Streak`, description: `Win ${m} matches in a row` });
+            }
+        }
+
+        for (const m of [3000, 3500, 4000, 4500, 5000]) {
+            if (prev.current_mmr < m && current.current_mmr >= m) {
+                achievements.push({ id: `mmr_${m}`, name: `${m} MMR`, description: `Reach ${m} MMR` });
+            }
+        }
+
+        for (const achievement of achievements) {
+            log.info(`[StatsWatcher] 🏆 ACHIEVEMENT: ${cached.username} - ${achievement.name}`);
+            
+            if (this.trophyWebhook) {
+                await this.trophyWebhook.sendAchievement({
+                    odinalId: cached.odinalId,
+                    username: cached.username,
+                    achievementId: achievement.id,
+                    achievementName: achievement.name,
+                    achievementDescription: achievement.description
+                });
+            }
+
+            if (this.metarenaWebhook) {
+                await this.metarenaWebhook.sendAchievement({
+                    odinalId: cached.odinalId,
+                    username: cached.username,
+                    achievementId: achievement.id,
+                    achievementName: achievement.name,
+                    achievementDescription: achievement.description
+                });
+            }
+        }
+    }
+
+    getStatus(): { running: boolean; playerCount: number } {
+        return {
+            running: this.isRunning,
+            playerCount: this.playerCache.size
+        };
+    }
+}
+
+export default StatsWatcher;

--- a/src/webhooks-metarena.ts
+++ b/src/webhooks-metarena.ts
@@ -1,0 +1,135 @@
+// ============================================================================
+// AUTHPROXY - METARENA WEBHOOK MODULE
+// Sends match events to MetArena for tournament tracking
+// ============================================================================
+
+import crypto from 'crypto';
+import axios from 'axios';
+import Logger from './logger';
+
+const log = new Logger();
+
+export interface MetArenaConfig {
+    enabled: boolean;
+    url: string;
+    secret: string;
+    serverId: string;
+    serverName: string;
+}
+
+export class MetArenaWebhook {
+    private config: MetArenaConfig;
+
+    constructor(config: MetArenaConfig) {
+        this.config = config;
+        if (config.enabled) {
+            log.info('[MetArena] Webhook enabled');
+            log.info(`[MetArena] Endpoint: ${config.url}`);
+        }
+    }
+
+    private generateSignature(payload: string): string {
+        if (!this.config.secret) return '';
+        return crypto
+            .createHmac('sha256', this.config.secret)
+            .update(payload)
+            .digest('hex');
+    }
+
+    private async send(event: string, data: any): Promise<boolean> {
+        if (!this.config.enabled) return false;
+
+        const payload = JSON.stringify({
+            event,
+            timestamp: new Date().toISOString(),
+            server_id: this.config.serverId,
+            server_name: this.config.serverName,
+            data
+        });
+
+        const signature = this.generateSignature(payload);
+
+        try {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'X-KOCity-Event': event,
+                'User-Agent': 'KOCity-AuthProxy/1.0'
+            };
+            
+            if (signature) {
+                headers['X-KOCity-Signature'] = signature;
+            }
+
+            const response = await axios.post(this.config.url, payload, {
+                headers,
+                timeout: 10000
+            });
+            log.info(`[MetArena] Sent ${event}: ${response.status}`);
+            return true;
+        } catch (error: any) {
+            log.err(`[MetArena] Failed to send ${event}: ${error.message}`);
+            return false;
+        }
+    }
+
+    async sendMatchComplete(data: {
+        odinalId: string;
+        username: string;
+        won: boolean;
+        isMvp: boolean;
+        mmrChange: number;
+        newMmr: number;
+        winStreak: number;
+        playlistGuid: string;
+    }): Promise<void> {
+        await this.send('match.completed', {
+            match_id: `koc_${Date.now()}`,
+            identifier: data.odinalId,
+            display_name: data.username,
+            winning_team: data.won ? 1 : 2,
+            team1_score: data.won ? 10 : 0,
+            team2_score: data.won ? 0 : 10,
+            team1_players: [{ identifier: data.odinalId, display_name: data.username }],
+            team2_players: [],
+            playlist_guid: data.playlistGuid,
+            mmr_change: data.mmrChange,
+            new_mmr: data.newMmr
+        });
+    }
+
+    async sendAchievement(data: {
+        odinalId: string;
+        username: string;
+        achievementId: string;
+        achievementName: string;
+        achievementDescription: string;
+    }): Promise<void> {
+        await this.send('achievement.unlocked', {
+            identifier: data.odinalId,
+            display_name: data.username,
+            achievement_id: data.achievementId,
+            achievement_name: data.achievementName,
+            achievement_description: data.achievementDescription
+        });
+    }
+
+    async sendPlayerConnected(odinalId: string, username: string, velanId: number): Promise<void> {
+        await this.send('player.connected', {
+            identifier: odinalId,
+            display_name: username,
+            velan_id: velanId,
+            connected_at: new Date().toISOString()
+        });
+    }
+
+    async sendPlayerDisconnected(odinalId: string, username: string, sessionSeconds: number): Promise<void> {
+        await this.send('player.disconnected', {
+            identifier: odinalId,
+            display_name: username,
+            session_duration_seconds: sessionSeconds,
+            disconnected_at: new Date().toISOString()
+        });
+    }
+}
+
+export default MetArenaWebhook;

--- a/src/webhooks-trophy.ts
+++ b/src/webhooks-trophy.ts
@@ -1,0 +1,134 @@
+// ============================================================================
+// AUTHPROXY - TROPHY WEBHOOK MODULE
+// Sends match events to Trophy Platform for achievement tracking
+// ============================================================================
+
+import crypto from 'crypto';
+import axios from 'axios';
+import Logger from './logger';
+
+const log = new Logger();
+
+export interface TrophyConfig {
+    enabled: boolean;
+    url: string;
+    secret: string;
+    gameSlug: string;
+}
+
+export class TrophyWebhook {
+    private config: TrophyConfig;
+
+    constructor(config: TrophyConfig) {
+        this.config = config;
+        if (config.enabled) {
+            log.info('[Trophy] Webhook enabled');
+            log.info(`[Trophy] Endpoint: ${config.url}`);
+        }
+    }
+
+    private generateSignature(payload: string): string {
+        if (!this.config.secret) return '';
+        return crypto
+            .createHmac('sha256', this.config.secret)
+            .update(payload)
+            .digest('hex');
+    }
+
+    private async send(event: string, data: any): Promise<boolean> {
+        if (!this.config.enabled) return false;
+
+        const payload = JSON.stringify({
+            event,
+            timestamp: new Date().toISOString(),
+            game_slug: this.config.gameSlug,
+            data
+        });
+
+        const signature = this.generateSignature(payload);
+
+        try {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'X-KOCity-Event': event,
+                'User-Agent': 'KOCity-AuthProxy/1.0'
+            };
+            
+            if (signature) {
+                headers['X-KOCity-Signature'] = signature;
+            }
+
+            const response = await axios.post(this.config.url, payload, {
+                headers,
+                timeout: 10000
+            });
+            log.info(`[Trophy] Sent ${event}: ${response.status}`);
+            return true;
+        } catch (error: any) {
+            log.err(`[Trophy] Failed to send ${event}: ${error.message}`);
+            return false;
+        }
+    }
+
+    async sendMatchComplete(data: {
+        odinalId: string;
+        username: string;
+        won: boolean;
+        isMvp: boolean;
+        mmrChange: number;
+        newMmr: number;
+        winStreak: number;
+        playlistGuid: string;
+    }): Promise<void> {
+        const player = { identifier: data.odinalId, display_name: data.username };
+        
+        await this.send('match.completed', {
+            match_id: `koc_${Date.now()}`,
+            winning_team: data.won ? 1 : 2,
+            team1_score: data.won ? 10 : 0,
+            team2_score: data.won ? 0 : 10,
+            team1_players: data.won ? [player] : [],
+            team2_players: data.won ? [] : [player],
+            duration_seconds: 180,
+            was_perfect_game: false,
+            was_comeback: false
+        });
+    }
+
+    async sendAchievement(data: {
+        odinalId: string;
+        username: string;
+        achievementId: string;
+        achievementName: string;
+        achievementDescription: string;
+    }): Promise<void> {
+        await this.send('player.milestone', {
+            identifier: data.odinalId,
+            display_name: data.username,
+            milestone_type: data.achievementId,
+            value: data.achievementName,
+            metadata: {
+                description: data.achievementDescription
+            }
+        });
+    }
+
+    async sendPlayerConnected(odinalId: string, username: string): Promise<void> {
+        await this.send('player.connected', {
+            identifier: odinalId,
+            display_name: username,
+            connected_at: new Date().toISOString()
+        });
+    }
+
+    async sendPlayerDisconnected(odinalId: string, username: string, sessionSeconds: number): Promise<void> {
+        await this.send('player.disconnected', {
+            identifier: odinalId,
+            display_name: username,
+            session_duration_seconds: sessionSeconds,
+            disconnected_at: new Date().toISOString()
+        });
+    }
+}
+
+export default TrophyWebhook;


### PR DESCRIPTION
…Add StatsWatcher module that monitors game DB for match completions- Add TrophyWebhook client for achievement tracking integration- Add MetArenaWebhook client for tournament bracket updates- Add config options (disabled by default)- Support HMAC-SHA256 signature verification for webhook securityAll features are opt-in via config.json or environment variables.

# Pull Request: Stats Watcher & Webhook Integration

## Summary

Adds optional Stats Watcher module that monitors the game database for match completions and sends webhooks to external platforms (Trophy Platform, MetArena). This enables third-party tournament platforms and achievement systems to integrate with KOCity servers.

All features are **disabled by default** and opt-in via configuration.

## Changes

### New Files
- `src/stats-watcher.ts` - Core module that polls game DB for stat changes
- `src/webhooks-trophy.ts` - Trophy Platform webhook client  
- `src/webhooks-metarena.ts` - MetArena webhook client

### Modified Files
- `src/config.ts` - Added statsWatcher, trophy, metarena config sections
- `config.json` - Added new config sections (all disabled by default)

**Step 1:** Add imports at the top:
```typescript
import { StatsWatcher } from './stats-watcher';
import { TrophyWebhook } from './webhooks-trophy';
import { MetArenaWebhook } from './webhooks-metarena';
```

**Step 2:** Add initialization after `prisma.$connect()` succeeds:
```typescript
// Initialize webhooks (if enabled in config)
const trophyWebhook = config.trophy.enabled ? new TrophyWebhook(config.trophy) : null;
const metarenaWebhook = config.metarena.enabled ? new MetArenaWebhook(config.metarena) : null;

// Initialize and start Stats Watcher (if enabled in config)
const statsWatcher = new StatsWatcher(config.statsWatcher, trophyWebhook, metarenaWebhook);
setTimeout(() => {
    statsWatcher.start().catch(err => {
        log.err(`Failed to start stats watcher: ${err.message}`);
    });
}, 2000);
```

**Note:** This does NOT modify any authentication code. The Stats Watcher is completely separate from the auth flow.

## Configuration

All features are **disabled by default**. Enable via `config.json` or environment variables:

### config.json
```json
{
    "statsWatcher": {
        "enabled": true,
        "gameDbUrl": "postgres://viper:viper@127.0.0.1:5434/viper",
        "pollIntervalMs": 5000
    },
    "trophy": {
        "enabled": true,
        "url": "https://trophy-backend.vercel.app/api/kocity",
        "secret": "optional-hmac-secret",
        "gameSlug": "knockout-city"
    },
    "metarena": {
        "enabled": true,
        "url": "https://metarena-api.vercel.app/api/kocity",
        "secret": "optional-hmac-secret",
        "serverId": "your-server-id"
    }
}
```

### Environment Variables
```bash
STATS_WATCHER_ENABLED=true
GAME_DB_URL=postgres://viper:viper@127.0.0.1:5434/viper
STATS_WATCHER_POLL_INTERVAL=5000

TROPHY_ENABLED=true
TROPHY_URL=https://trophy-backend.vercel.app/api/kocity
TROPHY_SECRET=your-secret
TROPHY_GAME_SLUG=knockout-city

METARENA_ENABLED=true
METARENA_URL=https://metarena-api.vercel.app/api/kocity
METARENA_SECRET=your-secret
METARENA_SERVER_ID=your-server-id
```

## How It Works

1. **Stats Watcher** connects to the game database (port 5434, separate from AuthProxy DB on 5432)
2. Polls the `skill` table every 5 seconds (configurable)
3. Detects when `total_games_played` increases (match completed)
4. Calculates win/loss, MVP status, MMR changes
5. Sends webhooks to configured endpoints
6. Checks for achievement milestones and sends those too

## Webhook Events

### match.completed
Sent when a player completes a match.

```json
{
    "event": "match.completed",
    "timestamp": "2025-12-24T01:00:00.000Z",
    "data": {
        "identifier": "12345",
        "display_name": "PlayerName",
        "won": true,
        "is_mvp": false,
        "mmr_change": 25,
        "new_mmr": 2525,
        "win_streak": 3,
        "playlist_guid": "30bf6eb0-3290-0d29-1ec4-f18701d86fa0"
    }
}
```

### player.milestone / achievement.unlocked
Sent when a player unlocks an achievement.

```json
{
    "event": "player.milestone",
    "timestamp": "2025-12-24T01:00:00.000Z",
    "data": {
        "identifier": "12345",
        "display_name": "PlayerName",
        "milestone_type": "first_win",
        "value": "First Victory",
        "metadata": {
            "description": "Win your first match"
        }
    }
}
```

## Achievement Milestones

- **Games**: First game
- **Wins**: 1, 10, 25, 50, 100, 250, 500, 1000
- **MVPs**: 1, 10, 25, 50, 100
- **Win Streaks**: 3, 5, 10, 20
- **MMR**: 3000, 3500, 4000, 4500, 5000

## Webhook Security

If a `secret` is configured, webhooks include an HMAC-SHA256 signature in the `X-KOCity-Signature` header. Receivers should verify this signature.

## Testing

1. Enable stats watcher in config
2. Start AuthProxy
3. Complete a match in Street Play mode (not Private Match)
4. Watch AuthProxy logs for `[StatsWatcher] MATCH COMPLETED`
5. Check webhook endpoint received the event

**Note**: Private Match mode does not record stats to the `skill` table.

## Related Projects

- **Trophy Platform**: Achievement tracking and sponsored rewards - https://trophy-backend.vercel.app
- **MetArena**: Tournament bracket management - https://metarena-api.vercel.app

## Authors

- Stats Watcher integration by Marcus Howard (Trophy/MetArena)
- Original AuthProxy by Ipmake, Tandashi, and kocity.xyz community